### PR TITLE
Fix build errors in case-sensitive filesystems

### DIFF
--- a/docs/SITE.js
+++ b/docs/SITE.js
@@ -5,6 +5,6 @@ module.exports = {
       require('./introduction/SITE.js'),
       require('./basics/SITE.js'),
       require('./advanced/SITE.js'),
-      require('./glossary.md'),
+      require('./Glossary.md'),
   ],
 }

--- a/docs/basics/SITE.js
+++ b/docs/basics/SITE.js
@@ -1,12 +1,12 @@
 module.exports = {
   title: 'Basics',
   index: [
-    require('./locations.md'),
-    require('./routes.md'),
-    require('./junctions.md'),
+    require('./Locations.md'),
+    require('./Routes.md'),
+    require('./Junctions.md'),
     require('./converting-locations-to-routes.md'),
     require('./the-screen-pattern.md'),
-    require('./links.md'),
+    require('./Links.md'),
     require('./example-contact-list.md'),
   ],
 }

--- a/docs/introduction/SITE.js
+++ b/docs/introduction/SITE.js
@@ -2,7 +2,7 @@ module.exports = {
   title: 'Introduction',
   index: [
     require('./do-i-need-a-router.md'),
-    require('./motivation.md'),
+    require('./Motivation.md'),
     require('./three-principles.md'),
     require('./locations-routes-and-maps.md'),
   ],


### PR DESCRIPTION
This fixes errors when building the `site/` folder because of case-sensitive matching (issue #9 )
Note: I haven't been able to test these changes on a Mac.