### PR TITLE
Fallback to monospace

### DIFF
--- a/site/views/MarkdownView.less
+++ b/site/views/MarkdownView.less
@@ -3,13 +3,13 @@
 @import '~prismjs/themes/prism-tomorrow.css';
 
 .MarkdownView {
-  pre, code { font-family: Monaco; line-height: 1.5 }
+  pre, code { font-family: Monaco, monospace; line-height: 1.5 }
   markdown { display: block; }
   markdown pre { background: rgb(45, 45, 45); padding: 10px; border-radius: 3px; }
   markdown pre code { font-size: 13px; white-space: pre-wrap; }
   markdown code { font-size: 16px; }
   markdown h1 { font-family: Monaco, monospace; margin: 40px 0 10px 0; font-size: 200%; }
-  markdown h2 { font-family: Monaco; margin: 30px 0 0 0; font-size: 150%; color: rgb(81, 81, 81); }
+  markdown h2 { font-family: Monaco, monospace; margin: 30px 0 0 0; font-size: 150%; color: rgb(81, 81, 81); }
   markdown h2 code { font-size: 100%; font-weight: 100; }
   markdown h2 + p { margin-top: 10px; }
 


### PR DESCRIPTION
Fallback to monospace font, to render correctly on systems that don't have the Monaco font (e.g. Windows).